### PR TITLE
Fix syntax error in RE Fonts doc

### DIFF
--- a/docs/rhoelements/FontsInRhoElements.txt
+++ b/docs/rhoelements/FontsInRhoElements.txt
@@ -24,7 +24,7 @@ The current version RhoElements will only understand TrueType fonts.  If you wis
             <StartPage  VALUE="file://\Program Files\RhoElements\HTML\Menu.htm" name="Menu"/>
           </General>
           <HTMLStyles>
-            <FontFamily <span class="xmlParameter">VALUE</span>="Tahoma" </b>/>
+            <FontFamily VALUE="Tahoma"/>
           </HTMLStyles>
         </Application>
       </Applications>


### PR DESCRIPTION
Noticed that there was an error with the syntax in the config.xml example on the Fonts in RhoElements page. Confirmed with Darryn Campbell that it is an error. Fixed it here.
