### PR TITLE
[#60948610] added ability to define code tutorials with tie in to Git pr...

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -5,6 +5,7 @@ development:
     - '../rhodes/res/generators/templates/api/xml_templates/'
     - '../rhoconnect-client/ext/rhoconnect-client/ext/'
   dirs:
+    tutorial: 'docs/tutorial/'
     api: 'docs/api/'
     guide: 'docs/guide/'
     rhosync: 'docs/rhosync/'
@@ -25,6 +26,7 @@ jenkins:
     - '../../rhodes/workspace/res/generators/templates/api/xml_templates/'
     - '../../rhoconnect-client/workspace/ext/rhoconnect-client/ext/'
   dirs:
+    tutorial: 'docs/tutorial/'
     api: 'docs/api/'
     guide: 'docs/guide/'
     rhosync: 'docs/rhosync/'
@@ -40,6 +42,7 @@ jenkins:
   pdfkithost: 'localhost:9393'
 edge:
   dirs:
+    tutorial: 'docs/tutorial/'
     api: 'docs/api/'
     guide: 'docs/guide/'
     rhosync: 'docs/rhosync/'
@@ -55,6 +58,7 @@ edge:
   pdfkithost: 'edgedocs.rhomobile.com'
 production:
   dirs:
+    tutorial: 'docs/tutorial/'
     api: 'docs/api/'
     guide: 'docs/guide/'
     rhosync: 'docs/rhosync/'

--- a/docs/tutorial/emberjs.step-0.txt
+++ b/docs/tutorial/emberjs.step-0.txt
@@ -1,0 +1,9 @@
+# EmberJS Tutorial
+
+Step 0
+
+##Section 1
+Section 1 text
+
+##Section 2
+Section 2 text

--- a/docs/tutorial/emberjs.step-1.txt
+++ b/docs/tutorial/emberjs.step-1.txt
@@ -1,0 +1,9 @@
+# EmberJS Tutorial
+
+Step 1
+
+##Section 1
+Section 1 text
+
+##Section 2
+Section 2 text

--- a/docs/tutorial/emberjs.step-2.txt
+++ b/docs/tutorial/emberjs.step-2.txt
@@ -1,0 +1,9 @@
+# EmberJS Tutorial
+
+Step 2
+
+##Section 1
+Section 1 text
+
+##Section 2
+Section 2 text

--- a/docs/tutorial/emberjs.txt
+++ b/docs/tutorial/emberjs.txt
@@ -1,0 +1,9 @@
+# EmberJS Tutorial
+
+Over view section
+
+##Section 1
+Section 1 text
+
+##Section 2
+Section 2 text

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -38,6 +38,7 @@ div#content {
 div#doc_container{
 	overflow: hidden;
     padding-bottom: 85px;
+    padding-left: 10px;
 }
 
 #docsnav {

--- a/tuts.rb
+++ b/tuts.rb
@@ -1,0 +1,13 @@
+
+tutorial 'emberjs', 'Using EmberJS in RhoMobile Apps','Javascript MVC','https://github.com/rhomobile/rhotut-emberjs' do
+  gitlabel 'step-0',                 'This is Step 0'
+  gitlabel 'step-1',                 'This is Step 1'
+  gitlabel 'step-2',                 'This is Step 2'
+
+end
+tutorial 'angularjs', 'Using AngularJS in RhoMobile Apps','Javascript MVC','https://github.com/rhomobile/rhotut-angularjs' do
+  gitlabel 'step-0',                 'This is Step 0'
+  gitlabel 'step-1',                 'This is Step 1'
+  gitlabel 'step-2',                 'This is Step 2'
+
+end

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -111,7 +111,21 @@
 			<% collapsed = true 
 			 first = true
 			%>
-	<% sections.each do |slug, title, sectgroup, topics| 
+	<% 
+	if !@steps.nil?
+		%>
+		<div class='well'>
+			<ul class='nav nav-list'>
+			<li class="nav-header"><a href="/tutorial/<%=@doc%>"><i class='icon '</i> <%=@docTitle %></a> </li>
+				  	
+			<% @steps.each do |gitlabel, title| %>
+				<li class="<%='active' if gitlabel == @step%>"><a href='/tutorial/<%=gitlabel%>/<%=@doc%>'><%=title%></a></li>
+			<% end %>
+			</ul>
+		</div>
+		 
+	<%else
+	sections.each do |slug, title, sectgroup, topics| 
 		
 		%>
 	<% if sectionGroup == sectgroup %>
@@ -160,8 +174,9 @@
 				
 		<% end %>
 		<% end %>
-	<% end %>
 		</ul>	
+	<% end %>
+	<% end %>
 		
 	</div>
 

--- a/views/tutorial.erb
+++ b/views/tutorial.erb
@@ -1,0 +1,44 @@
+<div id="rendered_topic_container" style="overflow:auto;padding-right: 5px;">
+	<div id="rendered_topic" data-title="Rhomobile | <%=h @title %>">
+		
+		<div class="row-fluid">
+			<ul doc-tutorial-nav="0" class="btn-group pull-left">
+				<%if @prevStep!=''%>
+					<li class="btn <%='disabled' if @prevStep==''%>"><a href="/tutorial/<%=@prevStep %>/<%=@doc %>"><i class="icon-step-backward"></i> Previous</a></li>
+				<% else %>
+					<li class="btn disabled"><i class="icon-step-backward"></i> Previous</li> 
+				<%end%>
+				
+				<%if @nextStep!=''%>
+				<li class="btn "><a href="/tutorial/<%=@nextStep %>/<%=@doc %>">Next <i class="icon-step-forward"></i></a></li>
+				<% else %>
+				<li class="btn disabled">Next <i class="icon-step-forward"></i></li>
+
+				<%end%>
+			</ul>
+			<%if !@codediffUrl.nil? %>
+			<ul class="btn-group pull-right">
+			
+				<li class="btn"><a href="<%=@codediffUrl%>" target="_blank"><i class="icon-search"></i> Code Diff</a></li>
+			</ul>
+
+				<%end%>
+		</div>
+
+		<div class="row-fluid">
+		<H1><%=@stepTitle%>
+		<%= @intro %>
+
+		</div>
+
+		<div class="row-fluid">
+		
+
+		<%= @body %>
+		</div>
+
+		
+		
+	</div>
+	<a href="/<%= topic_path %>">Back to Top</a>
+</div>


### PR DESCRIPTION
New mechanism for adding tutorials. 

tuts.rb defines the tutorial
tutorial [filename],[title],[group],[git-project-url]
do
  gitlabel [Stepname], [Title]
end

filename: name of overview file found in tutorial folder
title: title of tutorial to be displayed in menu
group: not used right now but will be to group tutorials
git-project-url: base url for project - used to display step comparisons

gitlabel:
Stepname: label used in git project, content of step mush be filename.Stepname.txt, also used in diff compare
title: used in menu

Ex:
tutorial 'emberjs', 'Using EmberJS in RhoMobile Apps','Javascript MVC','https://github.com/rhomobile/rhotut-emberjs' do
  gitlabel 'step-0',                 'This is Step 0'
  gitlabel 'step-1',                 'This is Step 1'
  gitlabel 'step-2',                 'This is Step 2'

end
