### PR TITLE
RMS4.1: new parameter added to rhoconfig.txt

### DIFF
--- a/docs/guide/runtime_config.txt
+++ b/docs/guide/runtime_config.txt
@@ -92,6 +92,9 @@ The `rhoconfig.txt` file generated with a new application contains the following
 	# on all other platforms and on Android from Rhodes >2.2.5 default 0
 	full_screen = 0
 	
+	# show top menu on Windows desktop in full screen mode (default is 0=don't show top menu)
+	#w32_fullscreen_menu = 1
+	
 	# disable the Android page loading progress bar
 	disable_loading_indication = 1
 	


### PR DESCRIPTION
enables menu in full screen mode on win32 desktop app
