### PR TITLE
Fixed SignalIndicators JS Synchronous Example

### DIFF
--- a/docs/en/4.0.0/api/signalindicators.txt
+++ b/docs/en/4.0.0/api/signalindicators.txt
@@ -47,7 +47,7 @@ app_type: "rhoelements"
             
   function signal_status_sync(){
 
-    signalValue = Rho.SignalIndicators.wlanStatus;
+    var signalValue = Rho.SignalIndicators.wlanStatus();
     console.log(signalValue);
     console.log("Signal Strength is: " + signalValue['signalStrength']);
   }


### PR DESCRIPTION
Previous code return undefined for all params due to improper method call.
