### PR TITLE
Scanner was able to scan the barcode when battery was low or critical 

### DIFF
--- a/docs/en/edge/guide/runtime_config.md
+++ b/docs/en/edge/guide/runtime_config.md
@@ -792,7 +792,7 @@ The following is an example of a typical configuration file
     <tr>
     <td>System\\LowBatteryScan</td>
     <td>LOWBATTERYSCAN</td>
-    <td>Windows Mobile and CE only.  Set to 0 to disable scanning when the battery is low or set to 1 to enable it.  Once disabled the scanner can be enabled again by calling <code>Barcode.enable</code>.</td>
+    <td>Windows Mobile and CE only.  Set to 0 to disable scanning when the battery is low/critical or set to 1 to enable it.</code>.</td>
     <td>0 - Disabled<BR>1 - Enabled</td>
     </tr>
 


### PR DESCRIPTION
Scanner was able to scan the barcode when battery was low or critical  even if the LowBatteryScan was set to false in config.xml or if user was setting the LowBatteryScan property to false.

Hence modified the implementation logic under 2.2 API & Common API of Barcode Module & also modified the document.
